### PR TITLE
Fix the latest tag is not obtained correctly through all branches [#4]

### DIFF
--- a/src/System/GitCommand.php
+++ b/src/System/GitCommand.php
@@ -51,7 +51,7 @@ class GitCommand implements GitCommandInterface
 
     /**
      * Converts trivial output contained as the first element of an array into a scalar value.
-     * @param $output
+     * @param string $output
      * @return string
      */
     private function formatTrivialOutput($output)
@@ -59,12 +59,24 @@ class GitCommand implements GitCommandInterface
         return (is_array($output) && isset($output[0])) ? $output[0] : '';
     }
 
+	/**
+	 * Executes the GIT command and returns the output as string.
+	 * Use this executor with GIT commands that output one line primitives.
+	 * @param string $parameters
+	 * @return string
+	 */
+	private function executeTriv($parameters)
+	{
+		return $this->formatTrivialOutput($this->execute($parameters));
+	}
+
     /**
      * {@inheritdoc}
      */
     public function getLastTag()
     {
-        return $this->formatTrivialOutput($this->execute('describe --abbrev=0'));
+		$lastTagId = $this->executeTriv('rev-list --tags --max-count=1');
+        return $this->executeTriv("describe --tags {$lastTagId}");
     }
 
     /**
@@ -82,7 +94,7 @@ class GitCommand implements GitCommandInterface
      */
     public function getUserName()
     {
-        return $this->formatTrivialOutput($this->execute('config --get user.name'));
+        return $this->executeTriv('config --get user.name');
     }
 
     /**
@@ -90,6 +102,6 @@ class GitCommand implements GitCommandInterface
      */
     public function getUserEmail()
     {
-        return $this->formatTrivialOutput($this->execute('config --get user.email'));
+        return $this->executeTriv('config --get user.email');
     }
 }

--- a/tests/unit/Chimney/System/GitCommandTest.php
+++ b/tests/unit/Chimney/System/GitCommandTest.php
@@ -42,7 +42,10 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
     public function getLastTag()
     {
         $tag = '1.0.5';
-        $this->executorProphet->execute('git', 'describe --abbrev=0')
+		$tagId = '0aa480ad1b3ab86ee99d2428eb7fd7c613d87907';
+		$this->executorProphet->execute('git', 'rev-list --tags --max-count=1')
+			->shouldBeCalledTimes(1)->willReturn($this->formatOutputForExec($tagId));
+        $this->executorProphet->execute('git', "describe --tags {$tagId}")
            ->shouldBeCalledTimes(1)->willReturn($this->formatOutputForExec($tag));
         $result = (new GitCommand($this->executorProphet->reveal()))->getLastTag();
         $this->assertEquals($tag, $result);


### PR DESCRIPTION
If you're on "next", but your latest tags are in "master", Git's "git describe --abbrev=0" won't return correct result. This is fixed now with
git describe --tags $(git rev-list --tags --max-count=1)
(of course, tanslated, so with no dependency on bash).